### PR TITLE
Fix/api translation inconsistency

### DIFF
--- a/functions/api/news.ts
+++ b/functions/api/news.ts
@@ -1,9 +1,12 @@
 import glossary from "./glossary.json";
 
+interface Env {
+  NEWS_TRANSLATIONS: KVNamespace;
+}
+
 function applyGlossary(text: string): string {
   let processed = text;
   for (const [short, full] of Object.entries(glossary)) {
-    // Use word boundary to avoid partial matches (e.g., AWAY)
     const regex = new RegExp(`\\b${short}\\b`, 'g');
     processed = processed.replace(regex, full);
   }
@@ -65,7 +68,8 @@ function extractThumbnail(itemXml: string): string {
   return "";
 }
 
-export const onRequest: PagesFunction = async (context) => {
+export const onRequest: PagesFunction<Env> = async (context) => {
+  const { env } = context;
   const cache = (caches as { default: Cache }).default;
   const url = new URL(context.request.url);
   const isNoCache = url.searchParams.has('nocache');
@@ -83,8 +87,8 @@ export const onRequest: PagesFunction = async (context) => {
   }
 
   const FEEDS = [
-    "https://www.abc.net.au/news/feed/51892/rss.xml", // Business
-    "https://www.abc.net.au/news/feed/1042/rss.xml"  // Politics
+    "https://www.abc.net.au/news/feed/51892/rss.xml",
+    "https://www.abc.net.au/news/feed/1042/rss.xml"
   ];
 
   const EXCLUDED_KEYWORDS = ["music", "arts", "fiction", "book", "movie", "film", "statue", "entertainment", "culture", "festival", "sculpture", "theatre"];
@@ -139,22 +143,15 @@ export const onRequest: PagesFunction = async (context) => {
     .filter((item): item is NonNullable<typeof item> => item !== null && item.title !== "" && item.link !== "")
     .sort((a, b) => b.pubDate - a.pubDate);
 
-    // Duplicate removal: Keep only the first (latest) occurrence of each link
     const seenLinks = new Set<string>();
     const uniqueItems = parsedItems.filter(item => {
       if (seenLinks.has(item.link)) return false;
       seenLinks.add(item.link);
       return true;
     }).slice(0, 15);
-interface Env {
-  NEWS_TRANSLATIONS: KVNamespace;
-}
 
-// ... inside onRequest ...
-const onRequest: PagesFunction<Env> = async (context) => {
-  const { env } = context;
-  const cache = (caches as { default: Cache }).default;
-// ...
+    if (uniqueItems.length === 0) throw new Error("No items passed the filter");
+
     const translatedNews = await Promise.all(
       uniqueItems.map(async (item) => {
         const cacheKeyJa = `ja:${item.link}`;
@@ -225,5 +222,3 @@ const onRequest: PagesFunction<Env> = async (context) => {
     });
   }
 };
-
-export default onRequest;

--- a/functions/api/news.ts
+++ b/functions/api/news.ts
@@ -146,17 +146,44 @@ export const onRequest: PagesFunction = async (context) => {
       seenLinks.add(item.link);
       return true;
     }).slice(0, 15);
+interface Env {
+  NEWS_TRANSLATIONS: KVNamespace;
+}
 
-    if (uniqueItems.length === 0) throw new Error("No items passed the filter");
-
+// ... inside onRequest ...
+export const onRequest: PagesFunction<Env> = async (context) => {
+  const { env } = context;
+  const cache = (caches as { default: Cache }).default;
+// ...
     const translatedNews = await Promise.all(
       uniqueItems.map(async (item) => {
-        const [titleJa, lineJa, titleId, lineId] = await Promise.all([
-          translateText(item.title, 'ja'),
-          translateText(item.firstLine, 'ja'),
-          translateText(item.title, 'id'),
-          translateText(item.firstLine, 'id')
+        const cacheKeyJa = `ja:${item.link}`;
+        const cacheKeyId = `id:${item.link}`;
+
+        const [cachedJa, cachedId] = await Promise.all([
+          env.NEWS_TRANSLATIONS.get(cacheKeyJa),
+          env.NEWS_TRANSLATIONS.get(cacheKeyId)
         ]);
+
+        let titleJa = cachedJa ? JSON.parse(cachedJa).title : null;
+        let lineJa = cachedJa ? JSON.parse(cachedJa).line : null;
+        let titleId = cachedId ? JSON.parse(cachedId).title : null;
+        let lineId = cachedId ? JSON.parse(cachedId).line : null;
+
+        if (!titleJa || !lineJa) {
+          titleJa = await translateText(item.title, 'ja');
+          lineJa = await translateText(item.firstLine, 'ja');
+          if (titleJa && lineJa) {
+            await env.NEWS_TRANSLATIONS.put(cacheKeyJa, JSON.stringify({ title: titleJa, line: lineJa }), { expirationTtl: 259200 });
+          }
+        }
+        if (!titleId || !lineId) {
+          titleId = await translateText(item.title, 'id');
+          lineId = await translateText(item.firstLine, 'id');
+          if (titleId && lineId) {
+            await env.NEWS_TRANSLATIONS.put(cacheKeyId, JSON.stringify({ title: titleId, line: lineId }), { expirationTtl: 259200 });
+          }
+        }
 
         return {
           title: item.title,

--- a/functions/api/news.ts
+++ b/functions/api/news.ts
@@ -10,18 +10,17 @@ function applyGlossary(text: string): string {
   return processed;
 }
 
-async function translateText(text: string, targetLang: string = 'ja'): Promise<string> {
-  if (!text) return "";
+async function translateText(text: string, targetLang: string = 'ja'): Promise<string | null> {
+  if (!text) return null;
   try {
     const expandedText = applyGlossary(text);
     const url = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=${targetLang}&dt=t&q=${encodeURIComponent(expandedText)}`;
     const response = await fetch(url);
-    // Explicit type for Google Translate response
     const data = await response.json() as unknown as [string[][], null, string];
-    return data[0].map((item: string[]) => item[0]).join("") || expandedText;
+    return data[0].map((item: string[]) => item[0]).join("") || null;
   } catch (e) {
     console.error(`Translation error (${targetLang}):`, e);
-    return text;
+    return null;
   }
 }
 
@@ -163,10 +162,10 @@ export const onRequest: PagesFunction = async (context) => {
           title: item.title,
           link: item.link,
           firstLine: item.firstLine,
-          title_ja: titleJa,
-          firstLine_ja: lineJa,
-          title_id: titleId,
-          firstLine_id: lineId,
+          title_ja: titleJa || "",
+          firstLine_ja: lineJa || "",
+          title_id: titleId || "",
+          firstLine_id: lineId || "",
           thumbnail: item.thumbnail,
           category: item.category,
           pubDate: item.displayDate

--- a/functions/api/news.ts
+++ b/functions/api/news.ts
@@ -151,7 +151,7 @@ interface Env {
 }
 
 // ... inside onRequest ...
-export const onRequest: PagesFunction<Env> = async (context) => {
+const onRequest: PagesFunction<Env> = async (context) => {
   const { env } = context;
   const cache = (caches as { default: Cache }).default;
 // ...
@@ -225,3 +225,5 @@ export const onRequest: PagesFunction<Env> = async (context) => {
     });
   }
 };
+
+export default onRequest;

--- a/functions/api/news.ts
+++ b/functions/api/news.ts
@@ -68,6 +68,10 @@ function extractThumbnail(itemXml: string): string {
   return "";
 }
 
+async function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 export const onRequest: PagesFunction<Env> = async (context) => {
   const { env } = context;
   const cache = (caches as { default: Cache }).default;
@@ -152,37 +156,82 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 
     if (uniqueItems.length === 0) throw new Error("No items passed the filter");
 
-    const translatedNews = await Promise.all(
+    // Phase 1: Parallel KV Lookup
+    const kvData = await Promise.all(
       uniqueItems.map(async (item) => {
         const cacheKeyJa = `ja:${item.link}`;
         const cacheKeyId = `id:${item.link}`;
-
         const [cachedJa, cachedId] = await Promise.all([
           env.NEWS_TRANSLATIONS.get(cacheKeyJa),
           env.NEWS_TRANSLATIONS.get(cacheKeyId)
         ]);
 
-        let titleJa = cachedJa ? JSON.parse(cachedJa).title : null;
-        let lineJa = cachedJa ? JSON.parse(cachedJa).line : null;
-        let titleId = cachedId ? JSON.parse(cachedId).title : null;
-        let lineId = cachedId ? JSON.parse(cachedId).line : null;
+        return {
+          item,
+          ja: cachedJa ? JSON.parse(cachedJa) : null,
+          id: cachedId ? JSON.parse(cachedId) : null
+        };
+      })
+    );
 
+    // Phase 2: Identify items needing translation
+    const results = new Array(uniqueItems.length);
+    const toTranslateIndices: number[] = [];
+
+    kvData.forEach((data, index) => {
+      if (data.ja && data.id) {
+        // Fully cached in KV
+        results[index] = {
+          title: data.item.title,
+          link: data.item.link,
+          firstLine: data.item.firstLine,
+          title_ja: data.ja.title,
+          firstLine_ja: data.ja.line,
+          title_id: data.id.title,
+          firstLine_id: data.id.line,
+          thumbnail: data.item.thumbnail,
+          category: data.item.category,
+          pubDate: data.item.displayDate
+        };
+      } else {
+        toTranslateIndices.push(index);
+      }
+    });
+
+    // Phase 3: Chunked Translation (10 items per chunk)
+    const CHUNK_SIZE = 10;
+    for (let i = 0; i < toTranslateIndices.length; i += CHUNK_SIZE) {
+      const chunk = toTranslateIndices.slice(i, i + CHUNK_SIZE);
+      
+      // Parallel within chunk
+      await Promise.all(chunk.map(async (index) => {
+        const data = kvData[index];
+        const item = data.item;
+
+        let titleJa = data.ja?.title || null;
+        let lineJa = data.ja?.line || null;
+        let titleId = data.id?.title || null;
+        let lineId = data.id?.line || null;
+
+        // Translate JA if missing
         if (!titleJa || !lineJa) {
           titleJa = await translateText(item.title, 'ja');
           lineJa = await translateText(item.firstLine, 'ja');
           if (titleJa && lineJa) {
-            await env.NEWS_TRANSLATIONS.put(cacheKeyJa, JSON.stringify({ title: titleJa, line: lineJa }), { expirationTtl: 259200 });
+            await env.NEWS_TRANSLATIONS.put(`ja:${item.link}`, JSON.stringify({ title: titleJa, line: lineJa }), { expirationTtl: 259200 });
           }
         }
+
+        // Translate ID if missing
         if (!titleId || !lineId) {
           titleId = await translateText(item.title, 'id');
           lineId = await translateText(item.firstLine, 'id');
           if (titleId && lineId) {
-            await env.NEWS_TRANSLATIONS.put(cacheKeyId, JSON.stringify({ title: titleId, line: lineId }), { expirationTtl: 259200 });
+            await env.NEWS_TRANSLATIONS.put(`id:${item.link}`, JSON.stringify({ title: titleId, line: lineId }), { expirationTtl: 259200 });
           }
         }
 
-        return {
+        results[index] = {
           title: item.title,
           link: item.link,
           firstLine: item.firstLine,
@@ -194,17 +243,22 @@ export const onRequest: PagesFunction<Env> = async (context) => {
           category: item.category,
           pubDate: item.displayDate
         };
-      })
-    );
+      }));
 
-    const resultResponse = new Response(JSON.stringify(translatedNews), {
+      // Wait if there are more chunks to process
+      if (i + CHUNK_SIZE < toTranslateIndices.length) {
+        await sleep(1000);
+      }
+    }
+
+    const resultResponse = new Response(JSON.stringify(results), {
       headers: { 
         "Content-Type": "application/json; charset=utf-8",
         "Cache-Control": "public, s-maxage=1800"
       }
     });
 
-    if (translatedNews.length > 0) {
+    if (results.length > 0) {
       try {
         context.waitUntil(cache.put(cacheKey, resultResponse.clone()));
       } catch (e) {

--- a/functions/api/news.ts
+++ b/functions/api/news.ts
@@ -198,8 +198,8 @@ export const onRequest: PagesFunction<Env> = async (context) => {
       }
     });
 
-    // Phase 3: Chunked Translation (10 items per chunk)
-    const CHUNK_SIZE = 10;
+    // Phase 3: Chunked Translation (5 items per chunk to stay within API limits)
+    const CHUNK_SIZE = 5;
     for (let i = 0; i < toTranslateIndices.length; i += CHUNK_SIZE) {
       const chunk = toTranslateIndices.slice(i, i + CHUNK_SIZE);
       

--- a/src/components/news/NewsCard.tsx
+++ b/src/components/news/NewsCard.tsx
@@ -17,12 +17,14 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
     minute: '2-digit'
   });
 
+  console.log('NewsCard debug:', { title: item.title, ja: item.title_ja, id: item.title_id });
+
   const title = isId 
-    ? (item.title_id || (console.log('Using English title_id fallback:', item.title), item.title)) 
-    : (item.title_ja || (console.log('Using English title_ja fallback:', item.title), item.title));
+    ? (item.title_id || item.title) 
+    : (item.title_ja || item.title);
   const description = isId 
-    ? (item.firstLine_id || (console.log('Using English firstLine_id fallback:', item.firstLine), item.firstLine)) 
-    : (item.firstLine_ja || (console.log('Using English firstLine_ja fallback:', item.firstLine), item.firstLine));
+    ? (item.firstLine_id || item.firstLine) 
+    : (item.firstLine_ja || item.firstLine);
 
   return (
     <article className="news-card">

--- a/src/components/news/NewsCard.tsx
+++ b/src/components/news/NewsCard.tsx
@@ -17,8 +17,12 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
     minute: '2-digit'
   });
 
-  const title = isId ? item.title_id : item.title_ja;
-  const description = isId ? item.firstLine_id : item.firstLine_ja;
+  const title = isId 
+    ? (item.title_id || item.title) 
+    : (item.title_ja || item.title);
+  const description = isId 
+    ? (item.firstLine_id || item.firstLine) 
+    : (item.firstLine_ja || item.firstLine);
 
   return (
     <article className="news-card">

--- a/src/components/news/NewsCard.tsx
+++ b/src/components/news/NewsCard.tsx
@@ -17,8 +17,6 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
     minute: '2-digit'
   });
 
-  console.log('NewsCard debug:', { title: item.title, ja: item.title_ja, id: item.title_id });
-
   const title = isId 
     ? (item.title_id || item.title) 
     : (item.title_ja || item.title);

--- a/src/components/news/NewsCard.tsx
+++ b/src/components/news/NewsCard.tsx
@@ -18,11 +18,11 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
   });
 
   const title = isId 
-    ? (item.title_id || item.title) 
-    : (item.title_ja || item.title);
+    ? (item.title_id || (console.log('Using English title_id fallback:', item.title), item.title)) 
+    : (item.title_ja || (console.log('Using English title_ja fallback:', item.title), item.title));
   const description = isId 
-    ? (item.firstLine_id || item.firstLine) 
-    : (item.firstLine_ja || item.firstLine);
+    ? (item.firstLine_id || (console.log('Using English firstLine_id fallback:', item.firstLine), item.firstLine)) 
+    : (item.firstLine_ja || (console.log('Using English firstLine_ja fallback:', item.firstLine), item.firstLine));
 
   return (
     <article className="news-card">

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,4 +4,4 @@ pages_build_output_dir = "dist"
 
 [[kv_namespaces]]
 binding = "NEWS_TRANSLATIONS"
-id = "7621495c277b4d1b827e7f5313337060"
+id = "f7b21548e6004b7d87da19264c73ac72"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,2 +1,6 @@
 name = "news-ja"
 compatibility_date = "2026-04-16"
+
+[[kv_namespaces]]
+binding = "NEWS_TRANSLATIONS"
+id = "7621495c277b4d1b827e7f5313337060"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,6 @@
 name = "news-ja"
 compatibility_date = "2026-04-16"
+pages_build_output_dir = "dist"
 
 [[kv_namespaces]]
 binding = "NEWS_TRANSLATIONS"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,4 +4,4 @@ pages_build_output_dir = "dist"
 
 [[kv_namespaces]]
 binding = "NEWS_TRANSLATIONS"
-id = "f7b21548e6004b7d87da19264c73ac72"
+id = "c717d150e9234d63a2229840bffe39ef"


### PR DESCRIPTION
 /api/news において、Google 翻訳 API
  のレート制限により一部の記事（主にリストの後半）が翻訳されず、英語のまま表示され 
  る問題を解決しました。Cloudflare KV
  を導入し、効率的なチャンク処理をバックエンドに実装することで、安定性とパフォーマ 
  ンスを大幅に向上させました。

  実施した主な変更
   1. Cloudflare KV による永続キャッシュの実装
       * 記事 URL をキー、翻訳結果（日本語・インドネシア語）を値として KV
         (NEWS_TRANSLATIONS) に保存。
       * 有効期限（TTL）を 3 日間に設定し、常に最新の翻訳を効率的に保持。
   2. バックエンドの翻訳ロジック最適化 (functions/api/news.ts)
       * KV への一括並列チェックを先に行い、翻訳が必要な記事のみを特定。
       * 翻訳 API の呼び出しを 5 件ずつのチャンクに分割し、グループ間に 1
         秒の待機を入れることで API 制限を確実に回避。
   3. フロントエンドの堅牢化 (NewsCard.tsx)
       * 翻訳済みフィールド (title_ja/title_id)
         が空の場合、自動的に原文の英語を表示するフォールバック処理を追加。
   4. 不具合の修正とリファクタリング
       * 関数の二重定義によるビルドエラーの解消。
       * wrangler.toml への pages_build_output_dir の追加。

  検証結果
   * KV および Cache API が空の「最大負荷状態」においても、全 15
     件の記事が日本語・インドネシア語ともに正常に翻訳されることを確認済み。        
   * 2回目以降のリクエストは KV
     から即座にデータが取得され、レスポンス速度が劇的に改善されていることを確認。  

  今後の課題
   * さらなる UX 向上と API
     負荷軽減のため、次フェーズで「カーソルベースのプログレッシブロード（段階的読み
     込み）」の実装を予定。