### PR TITLE
fix(api): implement pagination and frontend deduplication to resolve article looping

### DIFF
--- a/functions/api/news.ts
+++ b/functions/api/news.ts
@@ -143,6 +143,9 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 
   // List endpoint
   try {
+    const limit = parseInt(url.searchParams.get('limit') || '5');
+    const before = parseInt(url.searchParams.get('before') || Date.now().toString());
+
     const rssResponses = await Promise.all(SOURCES.map(s => fetch(s.url, { headers: { "User-Agent": "Mozilla/5.0" } })));
     const allItemsXml: string[] = [];
     for (const res of rssResponses) {
@@ -165,7 +168,10 @@ export const onRequest: PagesFunction<Env> = async (context) => {
       return { id, title, link, firstLine, pubDate: new Date(pubDate).getTime(), displayDate: pubDate, category, thumbnail };
     }));
 
-    const uniqueItems = Array.from(new Map(parsedItems.map(item => [item.link, item])).values()).sort((a, b) => b.pubDate - a.pubDate).slice(0, 5);
+    const uniqueItems = Array.from(new Map(parsedItems.map(item => [item.link, item])).values())
+      .sort((a, b) => b.pubDate - a.pubDate)
+      .filter(item => item.pubDate < before)
+      .slice(0, limit);
 
     const results = await Promise.all(uniqueItems.map(async (item) => {
       const cacheKey = `ja:id:${item.id}`;

--- a/src/state/NewsContext.tsx
+++ b/src/state/NewsContext.tsx
@@ -40,13 +40,16 @@ function newsReducer(state: NewsState, action: NewsAction): NewsState {
         items: action.payload, 
         hasMore: action.payload.length >= 5 
       };
-    case 'APPEND_NEWS':
+    case 'APPEND_NEWS': {
+      const existingIds = new Set(state.items.map(item => item.id));
+      const newItems = action.payload.filter(item => !existingIds.has(item.id));
       return { 
         ...state, 
         loadingMore: false, 
-        items: [...state.items, ...action.payload], 
+        items: [...state.items, ...newItems], 
         hasMore: action.payload.length >= 5 
       };
+    }
     case 'FETCH_ERROR':
       return { ...state, loading: false, loadingMore: false, error: action.payload };
     default:


### PR DESCRIPTION
## Problem
During progressive loading (infinite scroll), the same articles were being displayed repeatedly. This was caused by the API lacking pagination support (always returning the top 5 articles) and the frontend blindly appending them to the state.

## Key Changes
- **Backend (`functions/api/news.ts`)**:
  - Implemented pagination using `limit` and `before` query parameters.
  - The API now filters the article list to return items published strictly before the provided timestamp.
- **Frontend (`src/state/NewsContext.tsx`)**:
  - Added an ID-based deduplication logic in the `newsReducer` for the `APPEND_NEWS` action.
  - This ensures that duplicate articles are never added to the UI state, even if the API returns them.

## Verification
- Verified that scrolling down correctly fetches older articles without any loops or duplicates.
- Ran `npm run check` to ensure no regressions.