### PR TITLE
Update Node.js version in GitHub Actions to v24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
       
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
       
       - name: Install dependencies


### PR DESCRIPTION
This PR updates the Node.js version in GitHub Actions workflows to v24. This change is required because Wrangler v4.83.0 requires Node.js v22 or higher, and the previous v20 was being deprecated.

Closes #24