### PR TITLE
Feature/batch processing opt

### DIFF
--- a/functions/api/shared.ts
+++ b/functions/api/shared.ts
@@ -12,7 +12,7 @@ export interface Env {
   NEWS_QUEUE: Queue;
 }
 
-export interface NewsItem {
+export interface NewsDetail {
   id: string;
   title_ja: string;
   bodyJa: string;
@@ -21,6 +21,8 @@ export interface NewsItem {
   category: string;
   pubDate: number;
 }
+
+export type NewsItem = NewsDetail;
 
 export interface NewsMetadata {
   id: string;

--- a/src/types/news.ts
+++ b/src/types/news.ts
@@ -7,7 +7,7 @@ export interface NewsMetadata {
   snippet_ja: string;
 }
 
-export interface NewsItem {
+export interface NewsDetail {
   id: string;
   title_ja: string;
   bodyJa: string;
@@ -16,3 +16,5 @@ export interface NewsItem {
   category: string;
   pubDate: number;
 }
+
+export type NewsItem = NewsDetail;

--- a/workers/batch-summarizer/index.ts
+++ b/workers/batch-summarizer/index.ts
@@ -69,8 +69,8 @@ async function runTask(env: Env) {
     }
 
     // 4. キューへ詳細記事生成ジョブを投入
-    // ここでは一覧(sys:latest-news)の更新は行わない。
-    // 日本語化が完了した記事から順次、queueハンドラ内で一覧へ追加される。
+    // バッチプロデューサーは一覧 (`sys:latest-news`) の更新を行わず、
+    // 完了した記事はキュー処理側で一覧にデビューさせる。
     for (const item of latestItems) {
         await env.NEWS_QUEUE.send(item);
         console.log(`Queued article for processing: ${item.id}`);

--- a/workers/batch-summarizer/index.ts
+++ b/workers/batch-summarizer/index.ts
@@ -94,6 +94,9 @@ export default {
     const threeDaysAgo = Date.now() - (259200 * 1000);
     const pendingUpdates: NewsMetadata[] = [];
 
+    // Collect ids that hit cache so we can check snippet_ja presence in one KV GET
+    const idsToCheck = new Map<string, RawNewsItem>();
+
     for (const message of batch.messages) {
       const item = message.body;
       const cacheKey = `ja:id:${item.id}`;
@@ -104,42 +107,54 @@ export default {
         try {
           const { newsItem, snippet_ja } = await processNewsItem(item, env);
           // Prepare metadata for later batch update
-            pendingUpdates.push({
-              id: newsItem.id,
-              title_ja: newsItem.title_ja,
-              thumbnail: newsItem.thumbnail,
-              category: newsItem.category,
-              pubDate: newsItem.pubDate,
-              snippet_ja,
-            });
-            message.ack();
+          pendingUpdates.push({
+            id: newsItem.id,
+            title_ja: newsItem.title_ja,
+            thumbnail: newsItem.thumbnail,
+            category: newsItem.category,
+            pubDate: newsItem.pubDate,
+            snippet_ja,
+          });
+          message.ack();
         } catch (e) {
           console.error(`Error processing queued item ${item.id}`, e);
           message.retry();
           continue;
         }
       } else {
-        // Cache hit: ensure snippet_ja is present in the list metadata
+        // Cache hit: defer snippet presence checks until after loop to avoid repeated KV GET
         console.log(`Cache hit for article ${item.id}`);
-        try {
-          const listRaw = await env.NEWS_TRANSLATIONS.get("sys:latest-news");
-          const list: NewsMetadata[] = listRaw ? JSON.parse(listRaw) : [];
-          const existing = list.find(m => m.id === item.id);
-          if (existing && !("snippet_ja" in existing)) {
-            const { snippet_ja } = await processNewsItem(item, env);
-            pendingUpdates.push({ ...(existing as NewsMetadata), snippet_ja });
-            message.ack();
-          }
-        } catch (e) {
-          console.error(`Error handling cache hit for ${item.id}`, e);
-          message.retry();
-        }
+        idsToCheck.set(item.id, item);
+        message.ack();
       }
     }
-    // After processing all messages, merge pending updates into KV
+
+    // After processing all messages, perform a single sys:latest-news GET and fill missing snippets
     try {
       const listRaw = await env.NEWS_TRANSLATIONS.get("sys:latest-news");
       const currentList: NewsMetadata[] = listRaw ? JSON.parse(listRaw) : [];
+
+      if (idsToCheck.size > 0) {
+        for (const [id, item] of idsToCheck) {
+          const existing = currentList.find(m => m.id === id);
+          if (!existing || !("snippet_ja" in existing)) {
+            try {
+              const { newsItem, snippet_ja } = await processNewsItem(item, env);
+              pendingUpdates.push({
+                id: newsItem.id,
+                title_ja: newsItem.title_ja,
+                thumbnail: newsItem.thumbnail,
+                category: newsItem.category,
+                pubDate: newsItem.pubDate,
+                snippet_ja,
+              });
+            } catch (e) {
+              console.error(`Error generating snippet for cached article ${id}`, e);
+            }
+          }
+        }
+      }
+
       const merged = [...pendingUpdates, ...currentList];
       const uniqueList = Array.from(new Map(merged.map(m => [m.id, m])).values())
         .filter(m => m.pubDate > threeDaysAgo)

--- a/workers/batch-summarizer/index.ts
+++ b/workers/batch-summarizer/index.ts
@@ -137,39 +137,7 @@ export default {
           console.error(`Error processing queued item ${item.id}`);
           message.retry(); // 失敗したらリトライ
         }
-      } else {
-        // すでに詳細がある場合でも、一覧に含まれていない可能性（再構築中など）を考慮してマージを試みる
-        try {
-          const newsItem: NewsItem = JSON.parse(cached);
-          const listRaw = await env.NEWS_TRANSLATIONS.get("sys:latest-news");
-          const list: NewsMetadata[] = listRaw ? JSON.parse(listRaw) : [];
-          
-          if (!list.some(m => m.id === newsItem.id)) {
-            // ここでの修正: cachedには snippet_ja が含まれていないため、
-            // もしsnippetが必須であれば再生成が必要だが、ここではシンプルにマージのみ行う
-            // (本来は再生成すべき)
-            const metadata: NewsMetadata = {
-              id: newsItem.id,
-              title_ja: newsItem.title_ja,
-              thumbnail: newsItem.thumbnail,
-              category: newsItem.category,
-              pubDate: newsItem.pubDate,
-              snippet_ja: "" // 古い記事には一旦空文字列を入れる
-            };
-            // Keep only latest 100 items as a safety cap to stay well within 1MB KV limit and maintain frontend performance.
-            const newList = [metadata, ...list]
-              .filter(m => m.pubDate > (Date.now() - 259200 * 1000))
-              .sort((a, b) => b.pubDate - a.pubDate);
-            const uniqueList = Array.from(new Map(newList.map(m => [m.id, m])).values())
-              .slice(0, 100);
-            await env.NEWS_TRANSLATIONS.put("sys:latest-news", JSON.stringify(uniqueList));
-            console.log(`Existing article added back to list: ${newsItem.id}`);
-          }
-          message.ack();
-        } catch {
-          message.ack(); // パースエラーなどは無視
-        }
-      }
+
     }
   }
 };

--- a/workers/batch-summarizer/index.ts
+++ b/workers/batch-summarizer/index.ts
@@ -96,6 +96,73 @@ export default {
     return new Response('Not found', { status: 404 });
   },
   async queue(batch: MessageBatch<RawNewsItem>, env: Env): Promise<void> {
+  const threeDaysAgo = Date.now() - (259200 * 1000);
+  const pendingUpdates: NewsMetadata[] = [];
+
+  for (const message of batch.messages) {
+    const item = message.body;
+    const cacheKey = `ja:id:${item.id}`;
+    const cached = await env.NEWS_TRANSLATIONS.get(cacheKey);
+
+    if (!cached) {
+      console.log(`Processing new article from queue: ${item.title}`);
+      try {
+        const { newsItem, snippet_ja } = await processNewsItem(item, env);
+        // Prepare metadata for later batch update
+        pendingUpdates.push({
+          id: newsItem.id,
+          title_ja: newsItem.title_ja,
+          thumbnail: newsItem.thumbnail,
+          category: newsItem.category,
+          pubDate: newsItem.pubDate,
+          snippet_ja,
+        });
+      } catch (e) {
+        console.error(`Error processing queued item ${item.id}`, e);
+        message.retry();
+        continue;
+      }
+    } else {
+      // Cache hit: ensure snippet_ja is present in the list metadata
+      console.log(`Cache hit for article ${item.id}`);
+      try {
+        const listRaw = await env.NEWS_TRANSLATIONS.get("sys:latest-news");
+        const list: NewsMetadata[] = listRaw ? JSON.parse(listRaw) : [];
+        const existing = list.find(m => m.id === item.id);
+        if (existing && !("snippet_ja" in existing)) {
+          const { snippet_ja } = await processNewsItem(item, env);
+          pendingUpdates.push({
+            ...existing,
+            snippet_ja,
+          });
+        }
+      } catch (e) {
+        console.error(`Error handling cache hit for ${item.id}`, e);
+        message.retry();
+        continue;
+      }
+    }
+
+    // Acknowledge the message after handling (whether new or cache hit)
+    message.ack();
+  }
+
+  // Merge pending updates into the existing list and write once
+  try {
+    const listRaw = await env.NEWS_TRANSLATIONS.get("sys:latest-news");
+    const currentList: NewsMetadata[] = listRaw ? JSON.parse(listRaw) : [];
+    const merged = [...pendingUpdates, ...currentList];
+    const uniqueList = Array.from(new Map(merged.map(m => [m.id, m])).values())
+      .filter(m => m.pubDate > threeDaysAgo)
+      .sort((a, b) => b.pubDate - a.pubDate)
+      .slice(0, 100);
+    await env.NEWS_TRANSLATIONS.put("sys:latest-news", JSON.stringify(uniqueList));
+    console.log(`Batch metadata update completed with ${pendingUpdates.length} items`);
+  } catch (e) {
+    console.error("Error updating latest-news list after batch processing", e);
+  }
+}
+
     for (const message of batch.messages) {
       const item = message.body;
       const cacheKey = `ja:id:${item.id}`;

--- a/workers/batch-summarizer/index.ts
+++ b/workers/batch-summarizer/index.ts
@@ -7,12 +7,7 @@ import {
   processNewsItem,
   cleanThumbnailUrl
 } from "../../functions/api/shared";
-import type { 
-  Env, 
-  RawNewsItem,
-  NewsMetadata,
-  NewsItem
-} from "../../functions/api/shared";
+import type { Env, RawNewsItem, NewsMetadata } from "../../functions/api/shared";
 import { cleanHtml } from "../../functions/api/utils";
 
 async function runTask(env: Env) {
@@ -96,149 +91,64 @@ export default {
     return new Response('Not found', { status: 404 });
   },
   async queue(batch: MessageBatch<RawNewsItem>, env: Env): Promise<void> {
-  const threeDaysAgo = Date.now() - (259200 * 1000);
-  const pendingUpdates: NewsMetadata[] = [];
-
-  for (const message of batch.messages) {
-    const item = message.body;
-    const cacheKey = `ja:id:${item.id}`;
-    const cached = await env.NEWS_TRANSLATIONS.get(cacheKey);
-
-    if (!cached) {
-      console.log(`Processing new article from queue: ${item.title}`);
-      try {
-        const { newsItem, snippet_ja } = await processNewsItem(item, env);
-        // Prepare metadata for later batch update
-        pendingUpdates.push({
-          id: newsItem.id,
-          title_ja: newsItem.title_ja,
-          thumbnail: newsItem.thumbnail,
-          category: newsItem.category,
-          pubDate: newsItem.pubDate,
-          snippet_ja,
-        });
-      } catch (e) {
-        console.error(`Error processing queued item ${item.id}`, e);
-        message.retry();
-        continue;
-      }
-    } else {
-      // Cache hit: ensure snippet_ja is present in the list metadata
-      console.log(`Cache hit for article ${item.id}`);
-      try {
-        const listRaw = await env.NEWS_TRANSLATIONS.get("sys:latest-news");
-        const list: NewsMetadata[] = listRaw ? JSON.parse(listRaw) : [];
-        const existing = list.find(m => m.id === item.id);
-        if (existing && !("snippet_ja" in existing)) {
-          const { snippet_ja } = await processNewsItem(item, env);
-          pendingUpdates.push({
-            ...existing,
-            snippet_ja,
-          });
-        }
-      } catch (e) {
-        console.error(`Error handling cache hit for ${item.id}`, e);
-        message.retry();
-        continue;
-      }
-    }
-
-    // Acknowledge the message after handling (whether new or cache hit)
-    message.ack();
-  }
-
-  // Merge pending updates into the existing list and write once
-  try {
-    const listRaw = await env.NEWS_TRANSLATIONS.get("sys:latest-news");
-    const currentList: NewsMetadata[] = listRaw ? JSON.parse(listRaw) : [];
-    const merged = [...pendingUpdates, ...currentList];
-    const uniqueList = Array.from(new Map(merged.map(m => [m.id, m])).values())
-      .filter(m => m.pubDate > threeDaysAgo)
-      .sort((a, b) => b.pubDate - a.pubDate)
-      .slice(0, 100);
-    await env.NEWS_TRANSLATIONS.put("sys:latest-news", JSON.stringify(uniqueList));
-    console.log(`Batch metadata update completed with ${pendingUpdates.length} items`);
-  } catch (e) {
-    console.error("Error updating latest-news list after batch processing", e);
-  }
-}
+    const threeDaysAgo = Date.now() - (259200 * 1000);
+    const pendingUpdates: NewsMetadata[] = [];
 
     for (const message of batch.messages) {
       const item = message.body;
       const cacheKey = `ja:id:${item.id}`;
       const cached = await env.NEWS_TRANSLATIONS.get(cacheKey);
-      
+
       if (!cached) {
         console.log(`Processing new article from queue: ${item.title}`);
         try {
           const { newsItem, snippet_ja } = await processNewsItem(item, env);
-          
-          // 日本語化が完了した記事を一覧(sys:latest-news)にデビューさせる
-          const threeDaysAgo = Date.now() - (259200 * 1000);
-          const listRaw = await env.NEWS_TRANSLATIONS.get("sys:latest-news");
-          const list: NewsMetadata[] = listRaw ? JSON.parse(listRaw) : [];
-          
-          // メタデータの作成
-          const metadata: NewsMetadata = {
-            id: newsItem.id,
-            title_ja: newsItem.title_ja,
-            thumbnail: newsItem.thumbnail,
-            category: newsItem.category,
-            pubDate: newsItem.pubDate,
-            snippet_ja: snippet_ja
-          };
-
-          // マージ、重複排除、フィルタリング、ソート
-          // Keep only latest 100 items as a safety cap to stay well within 1MB KV limit and maintain frontend performance.
-          const newList = [metadata, ...list];
-          const uniqueList = Array.from(new Map(newList.map(m => [m.id, m])).values())
-            .filter(m => m.pubDate > threeDaysAgo)
-            .sort((a, b) => b.pubDate - a.pubDate)
-            .slice(0, 100);
-
-          await env.NEWS_TRANSLATIONS.put("sys:latest-news", JSON.stringify(uniqueList));
-          console.log(`Article debuted in list: ${newsItem.id}`);
-          
-          message.ack();
+          // Prepare metadata for later batch update
+            pendingUpdates.push({
+              id: newsItem.id,
+              title_ja: newsItem.title_ja,
+              thumbnail: newsItem.thumbnail,
+              category: newsItem.category,
+              pubDate: newsItem.pubDate,
+              snippet_ja,
+            });
+            message.ack();
         } catch (e) {
           console.error(`Error processing queued item ${item.id}`, e);
-          message.retry(); // 失敗したらリトリ	
+          message.retry();
+          continue;
         }
       } else {
         // Cache hit: ensure snippet_ja is present in the list metadata
         console.log(`Cache hit for article ${item.id}`);
         try {
-          const threeDaysAgo = Date.now() - (259200 * 1000);
           const listRaw = await env.NEWS_TRANSLATIONS.get("sys:latest-news");
           const list: NewsMetadata[] = listRaw ? JSON.parse(listRaw) : [];
-
           const existing = list.find(m => m.id === item.id);
-          // If metadata exists but lacks snippet_ja, generate it
           if (existing && !("snippet_ja" in existing)) {
             const { snippet_ja } = await processNewsItem(item, env);
-            const updatedMeta: NewsMetadata = {
-              id: item.id,
-              title_ja: existing.title_ja,
-              thumbnail: existing.thumbnail,
-              category: existing.category,
-              pubDate: existing.pubDate,
-              snippet_ja,
-            };
-            const newList = [updatedMeta, ...list.filter(m => m.id !== item.id)];
-            const uniqueList = Array.from(new Map(newList.map(m => [m.id, m])).values())
-              .filter(m => m.pubDate > threeDaysAgo)
-              .sort((a, b) => b.pubDate - a.pubDate)
-              .slice(0, 100);
-            await env.NEWS_TRANSLATIONS.put("sys:latest-news", JSON.stringify(uniqueList));
-            console.log(`補完: snippet_ja for ${item.id}`);
+            pendingUpdates.push({ ...(existing as NewsMetadata), snippet_ja });
+            message.ack();
           }
-          // Acknowledge message regardless of whether we updated or not
-          message.ack();
         } catch (e) {
           console.error(`Error handling cache hit for ${item.id}`, e);
           message.retry();
         }
       }
+    }
+    // After processing all messages, merge pending updates into KV
+    try {
+      const listRaw = await env.NEWS_TRANSLATIONS.get("sys:latest-news");
+      const currentList: NewsMetadata[] = listRaw ? JSON.parse(listRaw) : [];
+      const merged = [...pendingUpdates, ...currentList];
+      const uniqueList = Array.from(new Map(merged.map(m => [m.id, m])).values())
+        .filter(m => m.pubDate > threeDaysAgo)
+        .sort((a, b) => b.pubDate - a.pubDate)
+        .slice(0, 100);
+      await env.NEWS_TRANSLATIONS.put("sys:latest-news", JSON.stringify(uniqueList));
+      console.log(`Batch metadata update completed with ${pendingUpdates.length} items`);
+    } catch (e) {
+      console.error("Error updating latest-news list after batch processing", e);
     }
   }
 };

--- a/workers/batch-summarizer/index.ts
+++ b/workers/batch-summarizer/index.ts
@@ -7,8 +7,8 @@ import {
   processNewsItem,
   cleanThumbnailUrl
 } from "../../functions/api/shared";
-import type { Env, RawNewsItem, NewsMetadata } from "../../functions/api/shared";
-import { cleanHtml } from "../../functions/api/utils";
+import type { Env, RawNewsItem, NewsMetadata, NewsDetail } from "../../functions/api/shared";
+import { cleanHtml, smartTruncate } from "../../functions/api/utils";
 
 async function runTask(env: Env) {
   console.log('runTask started');
@@ -122,7 +122,7 @@ export default {
           continue;
         }
       } else {
-        // Cache hit: defer snippet presence checks until after loop to avoid repeated KV GET
+        // Cache hit: use cached detail if possible, but still update metadata later if snippet is missing.
         console.log(`Cache hit for article ${item.id}`);
         idsToCheck.set(item.id, item);
         message.ack();
@@ -138,6 +138,27 @@ export default {
         for (const [id, item] of idsToCheck) {
           const existing = currentList.find(m => m.id === id);
           if (!existing || !("snippet_ja" in existing)) {
+            const cachedDetailRaw = await env.NEWS_TRANSLATIONS.get(`ja:id:${id}`);
+            if (cachedDetailRaw) {
+              try {
+                const cachedDetail = JSON.parse(cachedDetailRaw) as NewsDetail;
+                if (cachedDetail.bodyJa) {
+                  const snippet_ja = smartTruncate(cachedDetail.bodyJa, 100);
+                  pendingUpdates.push({
+                    id: cachedDetail.id,
+                    title_ja: cachedDetail.title_ja,
+                    thumbnail: cachedDetail.thumbnail,
+                    category: cachedDetail.category,
+                    pubDate: cachedDetail.pubDate,
+                    snippet_ja,
+                  });
+                  continue;
+                }
+              } catch (e) {
+                console.error(`Failed to parse cached detail for ${id}`, e);
+              }
+            }
+
             try {
               const { newsItem, snippet_ja } = await processNewsItem(item, env);
               pendingUpdates.push({

--- a/workers/batch-summarizer/index.ts
+++ b/workers/batch-summarizer/index.ts
@@ -133,11 +133,45 @@ export default {
           console.log(`Article debuted in list: ${newsItem.id}`);
           
           message.ack();
-        } catch {
-          console.error(`Error processing queued item ${item.id}`);
-          message.retry(); // 失敗したらリトライ
+        } catch (e) {
+          console.error(`Error processing queued item ${item.id}`, e);
+          message.retry(); // 失敗したらリトリ	
         }
+      } else {
+        // Cache hit: ensure snippet_ja is present in the list metadata
+        console.log(`Cache hit for article ${item.id}`);
+        try {
+          const threeDaysAgo = Date.now() - (259200 * 1000);
+          const listRaw = await env.NEWS_TRANSLATIONS.get("sys:latest-news");
+          const list: NewsMetadata[] = listRaw ? JSON.parse(listRaw) : [];
 
+          const existing = list.find(m => m.id === item.id);
+          // If metadata exists but lacks snippet_ja, generate it
+          if (existing && !("snippet_ja" in existing)) {
+            const { snippet_ja } = await processNewsItem(item, env);
+            const updatedMeta: NewsMetadata = {
+              id: item.id,
+              title_ja: existing.title_ja,
+              thumbnail: existing.thumbnail,
+              category: existing.category,
+              pubDate: existing.pubDate,
+              snippet_ja,
+            };
+            const newList = [updatedMeta, ...list.filter(m => m.id !== item.id)];
+            const uniqueList = Array.from(new Map(newList.map(m => [m.id, m])).values())
+              .filter(m => m.pubDate > threeDaysAgo)
+              .sort((a, b) => b.pubDate - a.pubDate)
+              .slice(0, 100);
+            await env.NEWS_TRANSLATIONS.put("sys:latest-news", JSON.stringify(uniqueList));
+            console.log(`補完: snippet_ja for ${item.id}`);
+          }
+          // Acknowledge message regardless of whether we updated or not
+          message.ack();
+        } catch (e) {
+          console.error(`Error handling cache hit for ${item.id}`, e);
+          message.retry();
+        }
+      }
     }
   }
 };

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,3 +8,8 @@ binding = "AI"
 [[kv_namespaces]]
 binding = "NEWS_TRANSLATIONS"
 id = "5153c3cb172e445bb293d258ad1d4a0f"
+
+[env.preview]
+[[kv_namespaces]]
+binding = "NEWS_TRANSLATIONS"
+id = "4efa48672a7e438594cfe934a501498c"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,8 +8,3 @@ binding = "AI"
 [[kv_namespaces]]
 binding = "NEWS_TRANSLATIONS"
 id = "5153c3cb172e445bb293d258ad1d4a0f"
-
-[env.preview]
-[[kv_namespaces]]
-binding = "NEWS_TRANSLATIONS"
-id = "4efa48672a7e438594cfe934a501498c"


### PR DESCRIPTION
# [Optimization] Improve News Batch Processing and KV Data Design #35

## Overview
This PR introduces two major improvements:

1. **Data Structure Cleanup**  
   Move the Japanese snippet (`snippet_ja`) so it exists *only* in the metadata list (`sys:latest-news`).  
   Remove it from the detailed article data (`ja:id:<id>`).

2. **Backend Processing Optimization**  
   The current implementation updates `sys:latest-news` every time a single article is processed.  
   This PR consolidates those updates and performs **one final write at the end of the batch**, reducing KV operations and eliminating write‑conflict risks.

---

## Changes

### 1. Data Structure Cleanup
- `src/types/news.ts`: Remove `snippet_ja` from `NewsItem` (detailed article data).
- `functions/api/shared.ts`: Update `processNewsItem` so it returns `NewsItem` and `snippet_ja` separately.

### 2. Consolidated Backend Updates (Worker)
- `workers/batch-summarizer/index.ts`:
  - Remove per‑article writes to `sys:latest-news` inside the queue consumer.
  - Collect all pending updates during batch execution and write them to `sys:latest-news` **once at the end**.

### 3. Frontend Verification
- Confirm that the list API (`/api/news`) continues to return only metadata (including `snippet_ja`) and does **not** fetch unnecessary detailed fields such as `bodyJa`.

---

## Expected Benefits
- Eliminates redundant data between list metadata and detailed article entries.
- Reduces KV read/write operations during batch processing, lowering API costs and improving stability.
- Clarifies data ownership by fully separating list data from detailed article data.

---

## Issue
Closes #35
